### PR TITLE
Update wp-coding-standards/wpcs to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ ___________________
 
 # Changelog
 
+## Unreleased
+
+- Update `wp-coding-standards/wpcs` to `2.1.1` <sup>[Release Notes](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.1.1)</sup>
+
 ## 1.0.0
 
 - Update installation method

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
       }
     ],
     "require": {
-        "wp-coding-standards/wpcs": ">=2.1.0 <2.2.0",
+        "wp-coding-standards/wpcs": "2.1.1",
         "squizlabs/php_codesniffer": ">=3.3.1 <3.4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8245a200830971e0f9df41df608815d",
+    "content-hash": "a4436cfe208a9cd2b1d4effe522559d8",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -176,5 +176,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Can close https://github.com/WebDevStudios/php-coding-standards/issues/32

---------

I don't see anything controversial in this update.