### PR TITLE
Bump wpcs to >=2.3.0<3.0.0 and allow patch fixes in going forward.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ ___________________
 
 # Changelog
 
+## Unreleased
+
+- Update `wp-coding-standards/wpcs` to `>=2.3.0<3.0.0` to get `php-coding-standards` up to date with WP <sup>[PR](https://github.com/WebDevStudios/php-coding-standards/pull/38)</sup>
+
 ## 1.1.0
 
 - Update `wp-coding-standards/wpcs` to `2.1.1` <sup>[Release Notes](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.1.1)</sup>

--- a/composer.json
+++ b/composer.json
@@ -24,19 +24,11 @@
       }
     ],
     "require": {
-        "wp-coding-standards/wpcs": "2.1.1",
+        "wp-coding-standards/wpcs": "~2.3.0",
         "squizlabs/php_codesniffer": ">=3.3.1 <3.4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     },
     "extra": {
         "phpcodesniffer-search-depth": 5
-    },
-    "authors": [
-        {
-            "name": "Aubrey Portwood",
-            "email": "aubrey@webdevstudios.com",
-            "homepage": "http://webdevstudios.com/",
-            "role": "Developer"
-        }
-    ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4436cfe208a9cd2b1d4effe522559d8",
+    "content-hash": "3827fb0fe14770592ad30322c44b850f",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -125,16 +125,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -142,12 +142,13 @@
                 "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -157,7 +158,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -166,7 +167,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This does two things:

1. This gets our php coding standards in line with what WP is running at
2. This also will allow patch fixes to make it in going forward