### PR TITLE
Allow shorthand syntax, and warn on longform array() syntax.

### DIFF
--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -12,6 +12,33 @@
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
+
+		<!--
+		Allow Shorthand Syntax
+
+		WordPress decided to go for array() over [], we like [], and we discourage
+		array() [see below).]
+
+		@since 1.2.2
+		@see https://github.com/WordPress/WordPress-Coding-Standards/blob/2.2.0/WordPress-Core/ruleset.xml#L109
+		@see Generic.Arrays.DisallowLongArraySyntax.Found (Where we discourage array() syntax)
+		-->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+	</rule>
+
+	<!--
+	Warn on longform array syntax.
+
+	E.g. array().
+
+	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40
+	@since 1.2.2
+
+	May error in the future.
+	-->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
+		<type>warning</type>
+		<message>Short array syntax should be used to define arrays, in the future longform syntax will not be allowed.</message>
 	</rule>
 
 	<!-- Include WordPress-Docs -->

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -14,14 +14,18 @@
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
 
 		<!--
-		Allow Shorthand Syntax
+		Allow shorthand array syntax.
 
-		WordPress decided to go for array() over [], we like [], and we discourage
-		array() [see below).]
+		E.g. `[]`.
+
+		WordPress decided to go for `array()` over `[]`. WebDevStudios encourages the use of
+		shorthand syntax for readability and simplicity, and discourages use of shorthand
+		syntax for it's lack of readability due to it's use of parethensis and function-like
+		appearance.
 
 		@since 1.2.2
 		@see https://github.com/WordPress/WordPress-Coding-Standards/blob/2.2.0/WordPress-Core/ruleset.xml#L109
-		@see Generic.Arrays.DisallowLongArraySyntax.Found (Where we discourage array() syntax)
+		@see Generic.Arrays.DisallowLongArraySyntax.Found (Where we discourage `array()` syntax.)
 		-->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 	</rule>
@@ -33,6 +37,7 @@
 
 	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40
 	@since 1.2.2
+	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax (Where we encourage the use of shorthand syntax intead.)
 
 	May error in the future.
 	-->

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -14,6 +14,7 @@
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
 
 		<!--
+
 		Allow shorthand array syntax.
 
 		E.g. `[]`.
@@ -23,23 +24,30 @@
 		syntax for it's lack of readability due to it's use of parethensis and function-like
 		appearance.
 
+		@author Aubrey Portwood <aubrey@webdevstudios.com>
 		@since 1.2.2
-		@see https://github.com/WordPress/WordPress-Coding-Standards/blob/2.2.0/WordPress-Core/ruleset.xml#L109
-		@see Generic.Arrays.DisallowLongArraySyntax.Found (Where we discourage `array()` syntax.)
+
+		@see https://github.com/WebDevStudios/php-coding-standards/issues/40                                    Issue this resolves.
+		@see https://github.com/WordPress/WordPress-Coding-Standards/blob/2.2.0/WordPress-Core/ruleset.xml#L109 Where WordPress applies preference for `array()` syntax.
+		@see Generic.Arrays.DisallowLongArraySyntax.Found                                                       Where we discourage `array()` syntax.
 		-->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 	</rule>
 
 	<!--
+
 	Warn on longform array syntax.
 
+
 	E.g. array().
-
-	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40
-	@since 1.2.2
-	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax (Where we encourage the use of shorthand syntax intead.)
-
 	May error in the future.
+
+	@author Aubrey Portwood <aubrey@webdevstudios.com>
+	@since 1.2.2
+
+	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40 Issue this resolves.
+	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax W       here we encourage the use of shorthand syntax intead.
+
 	-->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
 		<type>warning</type>
@@ -58,6 +66,7 @@
 	</rule>
 
 	<!--
+
 	Support concatenated function calls.
 
 	This allows the following type of function call:
@@ -81,6 +90,7 @@
 
 	@since 1.2.0 (wds-coding-standards)
 	@author Aubrey Portwood <aubrey@webdevstudios.com>
+
 	-->
 	<rule ref="PEAR.Functions.FunctionCallSignature">
 	  <properties>
@@ -91,10 +101,12 @@
 	</rule>
 
 	<!--
+
 	Supports the concatenated function calls above.
 
 	@since 1.2.0 (wds-coding-standards)
 	@author Aubrey Portwood <aubrey@webdevstudios.com>
+
 	-->
 	<rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
 	<rule ref="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -44,7 +44,7 @@
 	@author Aubrey Portwood <aubrey@webdevstudios.com>
 	@since  1.3.0
 
-	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40 Issue this resolves.
+	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40 Issue that supports this.
 	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax         Where we encourage the use of shorthand syntax intead.
 
 	-->

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -50,7 +50,7 @@
 	-->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
 		<type>warning</type>
-		<message>Short array syntax should be used to define arrays; in the future, longform syntax will not be used</message>
+		<message>Short array syntax should be used to define arrays; in the future, longform syntax will not be used.</message>
 	</rule>
 
 	<!-- Include WordPress-Docs -->

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -25,7 +25,7 @@
 		appearance.
 
 		@author Aubrey Portwood <aubrey@webdevstudios.com>
-		@since 1.2.2
+		@since  1.3.0
 
 		@see https://github.com/WebDevStudios/php-coding-standards/issues/40                                    Issue this resolves.
 		@see https://github.com/WordPress/WordPress-Coding-Standards/blob/2.2.0/WordPress-Core/ruleset.xml#L109 Where WordPress applies preference for `array()` syntax.
@@ -43,7 +43,7 @@
 	May error in the future.
 
 	@author Aubrey Portwood <aubrey@webdevstudios.com>
-	@since 1.2.2
+	@since  1.3.0
 
 	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40 Issue this resolves.
 	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax W       here we encourage the use of shorthand syntax intead.

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -38,7 +38,7 @@
 	-->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
 		<type>warning</type>
-		<message>Short array syntax should be used to define arrays; in the future, longform syntax will not be used.</message>
+		<message>Short array syntax should be used to define arrays; in the future, longform syntax will not be used</message>
 	</rule>
 
 	<!-- Include WordPress-Docs -->

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -45,7 +45,7 @@
 	@since  1.3.0
 
 	@see   https://github.com/WebDevStudios/php-coding-standards/issues/40 Issue this resolves.
-	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax W       here we encourage the use of shorthand syntax intead.
+	@see   WordPress-Extra/Generic.Arrays.DisallowShortArraySyntax         Where we encourage the use of shorthand syntax intead.
 
 	-->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -38,7 +38,7 @@
 	-->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
 		<type>warning</type>
-		<message>Short array syntax should be used to define arrays, in the future longform syntax will not be allowed.</message>
+		<message>Short array syntax should be used to define arrays; in the future, longform syntax will not be used.</message>
 	</rule>
 
 	<!-- Include WordPress-Docs -->

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -38,7 +38,6 @@
 
 	Warn on longform array syntax.
 
-
 	E.g. array().
 	May error in the future.
 

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -63,16 +63,16 @@
 	This allows the following type of function call:
 
 	    thing( 'par1', [
-		    'par2array1',
-		    'par2array2',
+	      'par2array1',
+	      'par2array2',
 	    ] );
 
 
 	...which WPCS usually makes you do:
 
 	    $array = [
-		    'par2array1',
-		    'par2array2',
+	      'par2array1',
+	      'par2array2',
 	    ];
 
 	    thing( 'par1', $array );

--- a/examples/array-shorthand.php
+++ b/examples/array-shorthand.php
@@ -9,4 +9,4 @@
  */
 
 $shorthand = []; // Should not warn or error, as it's encouraged.
-$longform  = array(); // Should also not warn or error, but will discourage in the future.
+$longform  = array(); // Should warn, will become error in the future.

--- a/examples/array-shorthand.php
+++ b/examples/array-shorthand.php
@@ -5,7 +5,7 @@
  * @since   Unknown
  * @package None
  *
- * @purpose To ensure the shorthand version of arrays is still useable.
+ * @purpose To ensure the shorthand version of array syntax is encouraged over longform.
  */
 
 $shorthand = []; // Should not warn or error, as it's encouraged.


### PR DESCRIPTION
Allows shorthand `[]` syntax and warns about `array()` long-form syntax. Closes #40 

![image](https://user-images.githubusercontent.com/1753298/99306738-d00d7f80-2812-11eb-8ca6-54044cd3110c.png)
